### PR TITLE
[Current version] changes of finer grained locks when processing splitpartitions

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -881,6 +881,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def batchHandleChangePartitionNumThreads: Int = get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_THREADS)
   def batchHandleChangePartitionRequestInterval: Long =
     get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_INTERVAL)
+  def batchHandleChangePartitionParallelism: Int =
+    get(CLIENT_BATCH_HANDLE_CHANGE_PARTITION_PARALLELISM)
   def batchHandleCommitPartitionEnabled: Boolean = get(CLIENT_BATCH_HANDLE_COMMIT_PARTITION_ENABLED)
   def batchHandleCommitPartitionNumThreads: Int = get(CLIENT_BATCH_HANDLE_COMMIT_PARTITION_THREADS)
   def batchHandleCommitPartitionRequestInterval: Long =
@@ -894,7 +896,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def enableReadLocalShuffleFile: Boolean = get(READ_LOCAL_SHUFFLE_FILE)
   def readLocalShuffleThreads: Int = get(READ_LOCAL_SHUFFLE_THREADS)
   def readStreamCreatorPoolThreads: Int = get(READ_STREAM_CREATOR_POOL_THREADS)
-
+  
   def registerShuffleFilterExcludedWorkerEnabled: Boolean =
     get(REGISTER_SHUFFLE_FILTER_EXCLUDED_WORKER_ENABLED)
 
@@ -3633,7 +3635,16 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .booleanConf
       .createWithDefault(true)
-
+  
+  val CLIENT_BATCH_HANDLE_CHANGE_PARTITION_PARALLELISM: ConfigEntry[Int] =
+    buildConf("celeborn.client.shuffle.batchHandleChangePartition.parallelism")
+      .categories("client")
+      .internal
+      .doc("max number of threads which can concurrently processing requests")
+      .version("0.5.0")
+      .intConf
+      .createWithDefault(256)
+  
   val CLIENT_BATCH_HANDLE_CHANGE_PARTITION_THREADS: ConfigEntry[Int] =
     buildConf("celeborn.client.shuffle.batchHandleChangePartition.threads")
       .withAlternative("celeborn.shuffle.batchHandleChangePartition.threads")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
changes of finer grained locks when processing splitpartitions used. The bug mentioned in the celeborn repo https://github.com/apache/celeborn/pull/2532 is not included in this PR. 

However, there is still issues in this PR. The test result showed that with this change, a job can loss very small portion of shuffle data, like
```
stage 0: Shuffle Write Size / Records: 20.8 TiB / 1965259729
stage 1: Shuffle Read Size / Records: 20.8 TiB / 1965259122
```
Also, this data loss issue is not consistent, only got an incorrect shuffle read 1 out of 4 runs

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

